### PR TITLE
Add `prettier` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Available rule sets are:
 - [jsx](./config/jsx.js): Rules for when using JSX
 - [lodash-fp](./config/lodash-fp.js): Rules for when using Lodash's FP flavor
 - [mocha](./config/mocha.js): Rules for when using Mocha
+- [prettier](./config/prettier.js): Disables all stylistic rules but adds source code auto-formatting.

--- a/config/prettier.js
+++ b/config/prettier.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const prettierConfig = require('eslint-config-prettier');
+
+module.exports = {
+  plugins: ['prettier'],
+  rules: Object.assign({}, prettierConfig.rules, {
+    'prettier/prettier': [
+      'error',
+      {
+        singleQuote: true,
+        printWidth: 100,
+        bracketSpacing: false
+      }
+    ]
+  })
+};

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
     'es20XX': require('./config/es20XX'),
     'jsx': require('./config/jsx'),
     'lodash-fp': require('./config/lodash-fp'),
-    'mocha': require('./config/mocha')
-  },
+    'mocha': require('./config/mocha'),
+    'prettier': require('./config/prettier')
+  }
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "babel-eslint": "^7.0.0",
+    "eslint-config-prettier": "^1.5.0",
     "eslint-plugin-ava": "^4.2.0",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.2.0",
@@ -12,8 +13,10 @@
     "eslint-plugin-jsx": "0.0.2",
     "eslint-plugin-lodash-fp": "^2.1.3",
     "eslint-plugin-mocha": "^4.9.0",
+    "eslint-plugin-prettier": "^2.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-unicorn": "^2.1.1",
+    "prettier": "^0.22.0",
     "requireindex": "^1.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Add `prettier` config :)

Si on active cette configuration, elle désactive les règles stylistiques et les remplace par une énorme règle de fix. Par contre, la règle jette une erreur si tout n'est pas comme `prettier` le souhaite, donc on garde un check de style, mais qui sera plus facile à faire qu'avant.