### PR TITLE
Fix prettier version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "eslint-find-rules": "^1.14.0"
   },
   "scripts": {
-    "test": "npm run lint && node index.js && ava",
+    "test": "npm run lint && node index.js && npm run test:unit",
+    "test:unit": "ava",
     "find-missing": "npm run fm-core && npm run fm-ava && npm run fm-lodash-fp && npm run fm-mocha",
     "fm-core": "eslint-find-rules -v --unused ./config/core.js",
     "fm-ava": "eslint-find-rules -v --unused --no-core ./config/ava.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-prettier": "^2.0.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-unicorn": "^2.1.1",
-    "prettier": "^1.1.0",
+    "prettier": "1.3.1",
     "requireindex": "^1.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Il y a des mises à jour régulières de prettier, ce qui peut casser les tests. Cette PR fixe la version de prettier pour  éviter ça.

À l'écriture de ces lignes, la dernière version de prettier est la 1.4.2, mais je le fixe à la 1.3.1 car c'est celle que la plupart des projets ont (et elles n'auront du coup pas besoin d'être mis à jour pour faire passer les tests)

Après merge, il faudrait publier (un patch suffira)