### PR TITLE
Add use-expect rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "babel-eslint": "^8.0.1",
+    "eslint-ast-utils": "^1.1.0",
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-ava": "^4.2.2",
     "eslint-plugin-fp": "^2.3.0",
@@ -16,6 +17,7 @@
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-unicorn": "^2.1.2",
+    "lodash": "^4.17.4",
     "prettier": "^1.7.4",
     "requireindex": "^1.1.0"
   },

--- a/rules/use-expect.js
+++ b/rules/use-expect.js
@@ -1,0 +1,383 @@
+'use strict';
+
+const _ = require('lodash/fp');
+const astUtils = require('eslint-ast-utils');
+
+const isExpectCall = node => node.type === 'Identifier' && node.name === 'expect';
+
+const analyze = node => {
+  if (node.type === 'MemberExpression') {
+    const res = analyze(node.object);
+    return {
+      root: res.root,
+      args: res.args,
+      hasMultipleAssertions: res.hasMultipleAssertions,
+      properties: res.properties.concat(node.property.name)
+    };
+  }
+  if (node.type === 'CallExpression') {
+    if (isExpectCall(node.callee)) {
+      return {
+        root: node,
+        args: node.arguments,
+        hasMultipleAssertions: false,
+        properties: []
+      };
+    }
+    const res = analyze(node.callee);
+    return {
+      root: res.root,
+      args: res.args,
+      hasMultipleAssertions: true,
+      properties: res.properties
+    };
+  }
+  return {
+    root: node,
+    args: [],
+    hasMultipleAssertions: false,
+    properties: []
+  };
+};
+
+const flatten = array => array.reduce((a, b) => a.concat(b), []);
+const compact = array => array.filter(Boolean);
+
+const addToAndNegation = obj => {
+  Object.keys(obj).forEach(key => {
+    obj[key].properties = compact(
+      flatten(
+        obj[key].properties.map(value => [
+          compact(['to'].concat(value)),
+          !obj[key].disableNot && compact(['to', 'not'].concat(value))
+        ])
+      )
+    );
+  });
+  return obj;
+};
+
+const possibleProperties = addToAndNegation({
+  equal: {
+    properties: ['', 'deep'],
+    minArgs: 1
+  },
+  a: {
+    properties: [['be']],
+    minArgs: 1
+  },
+  above: {
+    properties: [['be']],
+    minArgs: 1,
+    disableNot: true
+  },
+  an: {
+    properties: [['be']],
+    minArgs: 1
+  },
+  below: {
+    properties: [['be']],
+    minArgs: 1,
+    disableNot: true
+  },
+  callCount: {
+    properties: [['have']],
+    minArgs: 1
+  },
+  calledWith: {
+    properties: [['have', 'been']],
+    minArgs: 1
+  },
+  closeTo: {
+    properties: [['be']],
+    minArgs: 1
+  },
+  contain: {
+    properties: [['']],
+    minArgs: 1
+  },
+  gt: {
+    properties: [['be']],
+    minArgs: 1,
+    disableNot: true
+  },
+  gte: {
+    properties: [['be']],
+    minArgs: 1,
+    disableNot: true
+  },
+  greaterThan: {
+    properties: [['be']],
+    minArgs: 1,
+    disableNot: true
+  },
+  include: {
+    properties: [['']],
+    minArgs: 1
+  },
+  instanceOf: {
+    properties: [['be', 'an']],
+    minArgs: 1
+  },
+  keys: {
+    properties: [['have', 'all'], ['have', 'any']],
+    minArgs: 1
+  },
+  least: {
+    properties: [['be', 'at']],
+    minArgs: 1,
+    disableNot: true
+  },
+  lessThan: {
+    properties: [['be']],
+    minArgs: 1,
+    disableNot: true
+  },
+  lt: {
+    properties: [['be']],
+    minArgs: 1,
+    disableNot: true
+  },
+  lte: {
+    properties: [['be']],
+    minArgs: 1,
+    disableNot: true
+  },
+  match: {
+    properties: [['']],
+    minArgs: 1
+  },
+  most: {
+    properties: [['be', 'at']],
+    minArgs: 1,
+    disableNot: true
+  },
+  property: {
+    properties: [['have'], ['have', 'nested']],
+    minArgs: 1
+  },
+  oneOf: {
+    properties: [['be']],
+    minArgs: 1
+  },
+  satisfy: {
+    properties: [['']],
+    minArgs: 1
+  },
+  string: {
+    properties: [['have']],
+    minArgs: 1
+  },
+  throw: {
+    properties: [['']],
+    minArgs: 0
+  },
+  within: {
+    properties: [['be']],
+    minArgs: 2
+  }
+});
+
+const primitives = ['Literal', 'TemplateLiteral'];
+const nonPrimitives = ['ArrayExpression', 'ObjectExpression'];
+
+const omitLoc = _.omit(['loc', 'range', 'start', 'end']);
+const removeLocation = obj => {
+  if (_.isArray(obj)) {
+    return _.map(removeLocation, obj);
+  }
+  if (_.isObject(obj)) {
+    return _.mapValues(removeLocation, omitLoc(obj));
+  }
+  return obj;
+};
+
+const toBeA_Check = type => (context, expression, properties, expectedValue) => {
+  if (expectedValue.type !== 'Literal') {
+    return;
+  }
+
+  if (expectedValue.raw !== expectedValue.raw.toLowerCase()) {
+    context.report({
+      node: expectedValue,
+      fix: fixer => fixer.replaceText(expectedValue, expectedValue.raw.toLowerCase()),
+      message: 'Expected type should be written in lower case'
+    });
+  }
+
+  const firstCharsAllowed = type === 'a' ? 'bcdfghjklmnpqrstvwxz' : 'aeiouy';
+
+  if (!firstCharsAllowed.includes(expectedValue.value.toLowerCase()[0])) {
+    const nodeToReplace = expression.callee.property;
+    context.report({
+      node: nodeToReplace,
+      fix: fixer => fixer.replaceText(nodeToReplace, type === 'a' ? 'an' : 'a'),
+      message:
+        type === 'a'
+          ? 'Use `an()` rather than `a()` when type starts with a vowel'
+          : 'Use `a()` rather than `an()` when type starts with a consonant'
+    });
+  }
+};
+
+const additionalChecks = {
+  equal: (context, expression, properties, expectedValue, comparedValue) => {
+    if (_.isEqual(removeLocation(expectedValue), removeLocation(comparedValue))) {
+      context.report({
+        node: expression,
+        message: 'Do not compare a value to itself'
+      });
+      return;
+    }
+    if (properties.includes('deep') && primitives.includes(expectedValue.type)) {
+      const nodeToReplace = expression.callee.object.property;
+      context.report({
+        node: expression,
+        fix: fixer => fixer.removeRange([nodeToReplace.range[0] - 1, nodeToReplace.range[1]]),
+        message: 'Remove `.deep` from assertion when comparing to a primitive'
+      });
+    }
+    if (!properties.includes('deep') && nonPrimitives.includes(expectedValue.type)) {
+      context.report({
+        node: expression,
+        fix: fixer => fixer.replaceText(expression.callee.property, 'deep.equal'),
+        message: 'Add `.deep` from assertion when comparing to a non-primitive'
+      });
+    }
+  },
+  a: toBeA_Check('a'),
+  an: toBeA_Check('an')
+};
+
+const formatPossibleProperties = obj => {
+  return obj.properties.filter(props => !props.includes('not')).map(props => {
+    const joined = props.join('.');
+    if (obj.disableNot) {
+      return joined;
+    }
+    return joined.replace(/to/g, 'to[.not]');
+  });
+};
+
+function create(context) {
+  return {
+    'ExpressionStatement[expression.type="MemberExpression"]': ({expression}) => {
+      const {root} = analyze(expression);
+      if (root.callee && isExpectCall(root.callee)) {
+        context.report({
+          node: root,
+          message: 'expect() statement should end with a function call'
+        });
+      }
+    },
+    'ExpressionStatement[expression.type="CallExpression"]': ({expression}) => {
+      if (expression.type === 'CallExpression' && isExpectCall(expression.callee)) {
+        context.report({
+          node: expression,
+          message: 'Missing assertion after `expect()` call'
+        });
+        return;
+      }
+
+      if (
+        expression.callee.type !== 'MemberExpression' ||
+        expression.callee.property.type !== 'Identifier'
+      ) {
+        return;
+      }
+
+      const {root, args, hasMultipleAssertions, properties} = analyze(expression.callee.object);
+      if (!root.callee || !isExpectCall(root.callee)) {
+        return;
+      }
+
+      if (properties.includes('and')) {
+        context.report({
+          node: root.callee,
+          message: 'Do not chain assertions using `.and.`'
+        });
+        return;
+      }
+
+      if (hasMultipleAssertions) {
+        context.report({
+          node: root.callee,
+          message: 'Do not chain multiple assertions'
+        });
+        return;
+      }
+
+      const methodName = expression.callee.property.name;
+      if (possibleProperties[methodName] === undefined) {
+        context.report({
+          node: expression.callee.property,
+          message: `Unknown assertion method ${methodName}`
+        });
+        return;
+      }
+      if (possibleProperties[methodName].minArgs > expression.arguments.length) {
+        context.report({
+          node: expression,
+          message: `${methodName}() expects at least ${possibleProperties[methodName]
+            .minArgs} argument(s)`
+        });
+        return;
+      }
+
+      if (args.length !== 1) {
+        context.report({
+          node: root.callee,
+          message: 'expect() takes exactly one argument'
+        });
+        return;
+      }
+
+      if (astUtils.computeStaticExpression(args[0]) !== undefined) {
+        context.report({
+          node: root.callee,
+          message: 'Do not evaluate expressions that can be computed statically'
+        });
+        return;
+      }
+
+      const isValid = possibleProperties[methodName].properties.some(props =>
+        _.isEqual(props, properties)
+      );
+
+      if (!isValid) {
+        const formattedPossibleProperties = formatPossibleProperties(
+          possibleProperties[methodName]
+        );
+        const replacement = properties.includes('not')
+          ? formattedPossibleProperties[0].replace(/[\]\[]/g, '')
+          : formattedPossibleProperties[0].replace(/\[\.not\]/, '');
+
+        const range = [
+          root.range[1] + 1,
+          _.getOr(root.range[1], 'callee.object.property.range.1', expression)
+        ];
+        context.report({
+          node: root,
+          fix: fixer =>
+            range[0] < range[1]
+              ? fixer.replaceTextRange(range, replacement)
+              : fixer.insertTextAfter(root, '.' + replacement),
+          message: `\`${methodName}()\` should be prefixed by: ${formattedPossibleProperties.join(
+            ' / '
+          )}`
+        });
+        return;
+      }
+
+      const check = additionalChecks[methodName] || _.noop;
+      check(context, expression, properties, expression.arguments[0], args[0]);
+    }
+  };
+}
+
+module.exports = {
+  create,
+  meta: {
+    fixable: 'code'
+  }
+};

--- a/test/use-expect.js
+++ b/test/use-expect.js
@@ -1,0 +1,329 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/use-expect';
+
+const ruleTester = avaRuleTester(test, {
+  env: {
+    es6: true
+  }
+});
+
+const error = message => ({
+  ruleId: 'use-expect',
+  message
+});
+
+const noCall = error('expect() statement should end with a function call');
+const unknownMethod = method => error(`Unknown assertion method ${method}`);
+const missingAssertion = error('Missing assertion after `expect()` call');
+const singleArgumentToExpect = error('expect() takes exactly one argument');
+const noAndAssertion = error('Do not chain assertions using `.and.`');
+const noMultipleAssertion = error('Do not chain multiple assertions');
+const primitiveEvaluation = error('Do not evaluate expressions that can be computed statically');
+
+ruleTester.run('use-expect', rule, {
+  valid: [
+    'expect(a).to.equal(b)',
+    'expect(a).to.not.equal(b)',
+    'expect(a).to.deep.equal(b)',
+    'expect(a).to.not.deep.equal(b)',
+    'expect(a).to.be.a("function")',
+    'expect(a).to.not.be.a("function")',
+    'expect(a).to.be.an("object")',
+    'expect(a).to.not.be.an("object")',
+    'expect(a).to.be.a(b)',
+    'expect(a).to.not.be.a(b)',
+    'expect(a).to.be.an(b)',
+    'expect(a).to.not.be.an(b)',
+    'expect(a).to.include("foo")',
+    'expect(a).to.not.include("foo")',
+    'expect(a).to.contain("foo")',
+    'expect(a).to.not.contain("foo")',
+    'expect(a).to.be.above(0)',
+    'expect(a).to.be.gt(0)',
+    'expect(a).to.be.gte(0)',
+    'expect(a).to.be.greaterThan(0)',
+    'expect(a).to.be.below(0)',
+    'expect(a).to.be.lessThan(0)',
+    'expect(a).to.be.lt(0)',
+    'expect(a).to.be.lte(0)',
+    'expect(a).to.be.within(0, 100)',
+    'expect(a).to.not.be.within(0, 100)',
+    'expect(a).to.be.at.least(0)',
+    'expect(a).to.be.at.most(0)',
+    'expect(a).to.be.an.instanceOf(0)',
+    'expect(a).to.not.be.an.instanceOf(0)',
+    'expect(a).to.match(/ok/)',
+    'expect(a).to.not.match(/ok/)',
+    'expect(a).to.throw()',
+    'expect(a).to.not.throw()',
+    'expect(a).to.throw(Error)',
+    'expect(a).to.not.throw(Error)',
+    'expect(a).to.satisfy(function(b) {return b > 2;})',
+    'expect(a).to.not.satisfy(function(b) {return b > 2;})',
+    'expect(a).to.be.closeTo(1.5, 1)',
+    'expect(a).to.not.be.closeTo(1.5, 1)',
+    'expect(a).to.be.oneOf([1, 2, 3])',
+    'expect(a).to.not.be.oneOf([1, 2, 3])',
+    'expect(a).to.have.property("foo")',
+    'expect(a).to.not.have.property("foo")',
+    'expect(a).to.have.all.keys("foo")',
+    'expect(a).to.not.have.all.keys("foo")',
+    'expect(a).to.have.any.keys("foo")',
+    'expect(a).to.not.have.any.keys("foo")',
+    'expect(a).to.have.callCount(1)',
+    'expect(a).to.not.have.callCount(1)',
+    'expect(a).to.have.been.calledWith("foo")',
+    'expect(a).to.not.have.been.calledWith("foo")',
+    'expect(a).to.equal("foo")',
+    'expect(a).to.equal(`1`)',
+    'expect(a).to.equal(1)',
+    'expect(a).to.deep.equal([])',
+    'expect(a).to.deep.equal({})',
+    'foo(a).to.be.a("function")',
+    'foo(a).to.bar.equal(b)',
+    'foo(a)',
+    'foo.a',
+    'foo.a.b'
+  ],
+  invalid: [
+    {
+      code: 'expect(a).to.be.undefined;',
+      output: 'expect(a).to.be.undefined;',
+      errors: [noCall]
+    },
+    {
+      code: 'expect(a).undefined;',
+      output: 'expect(a).undefined;',
+      errors: [noCall]
+    },
+    {
+      code: 'expect(a).be.oijfmozqijefqmzej',
+      output: 'expect(a).be.oijfmozqijefqmzej',
+      errors: [noCall]
+    },
+    {
+      code: 'expect(a).to.foobar(b)',
+      output: 'expect(a).to.foobar(b)',
+      errors: [unknownMethod('foobar')]
+    },
+    {
+      code: 'expect(a).to.woohoo(b)',
+      output: 'expect(a).to.woohoo(b)',
+      errors: [unknownMethod('woohoo')]
+    },
+    {
+      code: 'expect(a).to.be.equal(b)',
+      output: 'expect(a).to.equal(b)',
+      errors: [error('`equal()` should be prefixed by: to[.not] / to[.not].deep')]
+    },
+    {
+      code: 'expect(a).equal(b)',
+      output: 'expect(a).to.equal(b)',
+      errors: [error('`equal()` should be prefixed by: to[.not] / to[.not].deep')]
+    },
+    {
+      code: 'expect(a).not.to.equal(b)',
+      output: 'expect(a).to.not.equal(b)',
+      errors: [error('`equal()` should be prefixed by: to[.not] / to[.not].deep')]
+    },
+    {
+      code: 'expect(a).to.a(b)',
+      output: 'expect(a).to.be.a(b)',
+      errors: [error('`a()` should be prefixed by: to[.not].be')]
+    },
+    {
+      code: 'expect(a).to.an(b)',
+      output: 'expect(a).to.be.an(b)',
+      errors: [error('`an()` should be prefixed by: to[.not].be')]
+    },
+    {
+      code: 'expect(a).to.be.include(b)',
+      output: 'expect(a).to.include(b)',
+      errors: [error('`include()` should be prefixed by: to[.not]')]
+    },
+    {
+      code: 'expect(a).be.equal(b)',
+      output: 'expect(a).to.equal(b)',
+      errors: [error('`equal()` should be prefixed by: to[.not] / to[.not].deep')]
+    },
+    {
+      code: 'expect(a).to.not.be.gt(0)',
+      output: 'expect(a).to.be.gt(0)',
+      errors: [error('`gt()` should be prefixed by: to.be')]
+    },
+    {
+      code: 'expect(a).to.not.be.gte(0)',
+      output: 'expect(a).to.be.gte(0)',
+      errors: [error('`gte()` should be prefixed by: to.be')]
+    },
+    {
+      code: 'expect(a).to.not.be.greaterThan(0)',
+      output: 'expect(a).to.be.greaterThan(0)',
+      errors: [error('`greaterThan()` should be prefixed by: to.be')]
+    },
+    {
+      code: 'expect(a).to.not.be.below(0)',
+      output: 'expect(a).to.be.below(0)',
+      errors: [error('`below()` should be prefixed by: to.be')]
+    },
+    {
+      code: 'expect(a).to.not.be.lessThan(0)',
+      output: 'expect(a).to.be.lessThan(0)',
+      errors: [error('`lessThan()` should be prefixed by: to.be')]
+    },
+    {
+      code: 'expect(a).to.not.be.lt(0)',
+      output: 'expect(a).to.be.lt(0)',
+      errors: [error('`lt()` should be prefixed by: to.be')]
+    },
+    {
+      code: 'expect(a).to.not.be.lte(0)',
+      output: 'expect(a).to.be.lte(0)',
+      errors: [error('`lte()` should be prefixed by: to.be')]
+    },
+    {
+      code: 'expect(a).to.not.be.at.least(0)',
+      output: 'expect(a).to.be.at.least(0)',
+      errors: [error('`least()` should be prefixed by: to.be.at')]
+    },
+    {
+      code: 'expect(a).to.not.be.at.most(0)',
+      output: 'expect(a).to.be.at.most(0)',
+      errors: [error('`most()` should be prefixed by: to.be.at')]
+    },
+    {
+      code: 'expect(a)',
+      output: 'expect(a)',
+      errors: [missingAssertion]
+    },
+    {
+      code: 'expect(a).to.be.an("array").and.to.deep.equal([1]);',
+      output: 'expect(a).to.be.an("array").and.to.deep.equal([1]);',
+      errors: [noAndAssertion]
+    },
+    {
+      code: 'expect(a).to.be.undefined.and.not.to.deep.equal([1]);',
+      output: 'expect(a).to.be.undefined.and.not.to.deep.equal([1]);',
+      errors: [noAndAssertion]
+    },
+    {
+      code: 'expect(foo).to.have.property("bar").to.be.an("object");',
+      output: 'expect(foo).to.have.property("bar").to.be.an("object");',
+      errors: [noMultipleAssertion]
+    },
+    {
+      code: 'expect(a).to.deep.equal("string")',
+      output: 'expect(a).to.equal("string")',
+      errors: [error('Remove `.deep` from assertion when comparing to a primitive')]
+    },
+    {
+      code: 'expect(a).to.deep.equal(`1`)',
+      output: 'expect(a).to.equal(`1`)',
+      errors: [error('Remove `.deep` from assertion when comparing to a primitive')]
+    },
+    {
+      code: 'expect(a).to.deep.equal(1)',
+      output: 'expect(a).to.equal(1)',
+      errors: [error('Remove `.deep` from assertion when comparing to a primitive')]
+    },
+    {
+      code: 'expect(a).to.equal([])',
+      output: 'expect(a).to.deep.equal([])',
+      errors: [error('Add `.deep` from assertion when comparing to a non-primitive')]
+    },
+    {
+      code: 'expect(a).to.equal({})',
+      output: 'expect(a).to.deep.equal({})',
+      errors: [error('Add `.deep` from assertion when comparing to a non-primitive')]
+    },
+    {
+      code: 'expect().to.equal(1)',
+      output: 'expect().to.equal(1)',
+      errors: [singleArgumentToExpect]
+    },
+    {
+      code: 'expect(a, b).to.equal(1)',
+      output: 'expect(a, b).to.equal(1)',
+      errors: [singleArgumentToExpect]
+    },
+    {
+      code: 'expect(1).to.equal(a)',
+      output: 'expect(1).to.equal(a)',
+      errors: [primitiveEvaluation]
+    },
+    {
+      code: 'expect("foo").to.equal(a)',
+      output: 'expect("foo").to.equal(a)',
+      errors: [primitiveEvaluation]
+    },
+    {
+      code: 'expect(`foo`).to.equal(a)',
+      output: 'expect(`foo`).to.equal(a)',
+      errors: [primitiveEvaluation]
+    },
+    {
+      code: 'expect(`foo` + "bar").to.equal(a)',
+      output: 'expect(`foo` + "bar").to.equal(a)',
+      errors: [primitiveEvaluation]
+    },
+    {
+      code: 'expect(1 + 1).to.equal(a)',
+      output: 'expect(1 + 1).to.equal(a)',
+      errors: [primitiveEvaluation]
+    },
+    {
+      code: 'expect(a).to.equal()',
+      output: 'expect(a).to.equal()',
+      errors: [error('equal() expects at least 1 argument(s)')]
+    },
+    {
+      code: 'expect(a).to.be.within(1)',
+      output: 'expect(a).to.be.within(1)',
+      errors: [error('within() expects at least 2 argument(s)')]
+    },
+    {
+      code: 'expect(a).to.equal(a)',
+      output: 'expect(a).to.equal(a)',
+      errors: [error('Do not compare a value to itself')]
+    },
+    {
+      code: 'expect(a).to.be.a("Function")',
+      output: 'expect(a).to.be.a("function")',
+      errors: [error('Expected type should be written in lower case')]
+    },
+    {
+      code: 'expect(a).to.be.a("FUNCTION")',
+      output: 'expect(a).to.be.a("function")',
+      errors: [error('Expected type should be written in lower case')]
+    },
+    {
+      code: 'expect(a).to.be.an("Object")',
+      output: 'expect(a).to.be.an("object")',
+      errors: [error('Expected type should be written in lower case')]
+    },
+    {
+      code: 'expect(a).to.be.an("OBJECT")',
+      output: 'expect(a).to.be.an("object")',
+      errors: [error('Expected type should be written in lower case')]
+    },
+    {
+      code: 'expect(a).to.be.a("object")',
+      output: 'expect(a).to.be.an("object")',
+      errors: [error('Use `an()` rather than `a()` when type starts with a vowel')]
+    },
+    {
+      code: 'expect(a).to.be.an("function")',
+      output: 'expect(a).to.be.a("function")',
+      errors: [error('Use `a()` rather than `an()` when type starts with a consonant')]
+    },
+    {
+      code: 'expect(a).to.be.an("FUNCTION")',
+      output: 'expect(a).to.be.a("function")',
+      errors: [
+        error('Use `a()` rather than `an()` when type starts with a consonant'),
+        error('Expected type should be written in lower case')
+      ]
+    }
+  ]
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,6 +1302,13 @@ eslint-ast-utils@^1.0.0:
   dependencies:
     lodash.get "^4.4.2"
 
+eslint-ast-utils@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz#3d58ba557801cfb1c941d68131ee9f8c34bd1586"
+  dependencies:
+    lodash.get "^4.4.2"
+    lodash.zip "^4.2.0"
+
 eslint-ava-rule-tester@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/eslint-ava-rule-tester/-/eslint-ava-rule-tester-2.0.2.tgz#543a13a5dcf326e3e700a2f05ebb6886451802c1"
@@ -1382,7 +1389,7 @@ eslint-plugin-json@^1.2.0:
   dependencies:
     jshint "^2.8.0"
 
-eslint-plugin-jsx@^0.0.2:
+eslint-plugin-jsx@0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/eslint-plugin-jsx/-/eslint-plugin-jsx-0.0.2.tgz#64b6621d70dc7098dd14a189b1427c70e34cb230"
   dependencies:
@@ -2520,6 +2527,10 @@ lodash.snakecase@^4.0.1:
 lodash.upperfirst@^4.2.0:
   version "4.3.1"
   resolved "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
+
+lodash.zip@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
 
 lodash@3.7.x:
   version "3.7.0"


### PR DESCRIPTION
Ajout d'une règle pour utiliser correctement `expect` de `chai`
(Toutes les erreurs suivantes ont été vus au moins dans le MOOC)

- Interdiction d'utiliser expect avec un nombre de paramètres différent de 1. Ex: `expect();` (sauf celle-là que je n'ai pas trouvé)
- Interdiction d'utiliser expect sans assertion. Ex: `expect(a);`
- Interdiction d'évaluer des valeurs statiques. Ex: `expect(1).to.equal(a);`
- Interdiction de faire des évaluations toujours vraies. Ex: `expect(a).to.equal(a);`
- Obligation de terminer l'assertion par un appel de fonction: `expect(a).to.equal(undefined)` vs `expect(a).to.be.undefined`. Ça évite d'avoir des assertions non-mises en pratique parce qu'on a fait une typo du style `expect(a).to.be.undefinde` (en plus ça enlève le côté magique des assertions de chai).
- Interdiction d'utiliser des assertions inconnues: `expect(a).to.foobar()`. Les méthodes sont hard-codées dans la règle, et toutes les méthodes de `chai` ne sont pas disponibles. Le but est aussi d'interdir celles qui sont bien compliqués (i.e. il faut aller lire la doc pour comprendre comment marche l'assertion) pour les remplacer par des assertions plusse vanilla.
- Obligation de préfixer l'assertion dans un anglais correct et consistant : [AUTOFIX]
  - `expect(a).to.equal(1)` et non `expect(a).to.be.equal(1)`, `expect(a).be.equal(1)`, `expect(a).equal(1)`, ...
  - `expect(a).to.not.equal(1)` et non `expect(a).not.equal(1)`, `expect(a).not.to.equal(1)`
  - `expect(a).to.be.a('function')` et non `expect(a).be.to.a('function')`, ...
  - Et correction pour toutes les autres assertions
- Bonne utilisation de `a`/`an`:
  - Utilisation de `a`/`an` en fonction de la première lettre du type attendu [AUTOFIX]
    - `expect(a).to.be.an('function')` --> `expect(a).to.be.a('function')`
    - `expect(a).to.be.a('object')` --> `expect(a).to.be.an('object')`
  - Le type attendu doit être minuscule [AUTOFIX]
    - `expect(a).to.be.a('Function')` --> `expect(a).to.be.a('function')`
    - `expect(a).to.be.a('FUNCTION')` --> `expect(a).to.be.a('function')`
- Interdiction d'utiliser la négation pour les assertions de comparaisons (excepté l'égalité) [SEMI AUTOFIX, ça enlève juste la négation]
    - `expect(a).to.not.be.above(1)` devrait être `expect(a).to.be.lte(1)` mais serait autofixé en `expect(a).to.be.above(1)`
- Interdiction d'enchaîner des assertions via (ou non) `.and`. Ça rend super complexe l'analyse de l'assertion (surtout au niveau de l'anglais), et ça peut rendre plus compliqué de savoir de quelle assertion provient une erreur, alors que c'est pas plus compliqué de faire les assertions en plusieurs instructions. Exemples: `expect(foo).to.have.property("bar").to.be.an("object");` ou `expect(a).to.be.an("array").and.to.deep.equal([1]);`
- Bonne utilisation de `.deep` dans les assertions `equal()` [AUTOFIX]
  - `expect(a).to.deep.equal(1)` --> `expect(a).to.equal(1)`
  - `expect(a).to.equal(1)` --> `expect(a).to.deep.equal([1, 2, 3])`