### PR TITLE
Add rule no-async-callback

### DIFF
--- a/config/core.js
+++ b/config/core.js
@@ -38,6 +38,7 @@ module.exports = {
     'promise/prefer-await-to-callbacks': 'off',
     'promise/prefer-await-to-then': 'off',
 
+    '@coorpacademy/coorpacademy/no-async-callback': 'error',
     '@coorpacademy/coorpacademy/no-dangerous-logs': 'error',
 
     'import/default': 'error',

--- a/rules/no-async-callback.js
+++ b/rules/no-async-callback.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const defaultCallbackNames = ['done', 'cb', 'callback', 'next'];
+
+function create(context) {
+  const options = context.options[0] || {};
+  const callbackNames = options.callbacks || defaultCallbackNames;
+  const checkFunction = node => {
+    const callbackParam = node.params.find(
+      param => param.type === 'Identifier' && callbackNames.includes(param.name)
+    );
+
+    if (callbackParam && node.async) {
+      context.report({
+        node: callbackParam,
+        message: 'Do not use callback parameters inside an async function'
+      });
+    }
+  };
+
+  return {
+    ArrowFunctionExpression: checkFunction,
+    FunctionDeclaration: checkFunction,
+    FunctionExpression: checkFunction
+  };
+}
+
+const schema = [
+  {
+    type: 'object',
+    properties: {
+      callbacks: {
+        type: 'array'
+      }
+    }
+  }
+];
+
+module.exports = {
+  create,
+  meta: {
+    schema
+  }
+};

--- a/test/index.js
+++ b/test/index.js
@@ -9,5 +9,8 @@ test('index should contain all configurations', t => {
 });
 
 test('index should contain all rules', t => {
-  t.deepEqual(Object.keys(m.rules).sort(), ['no-dangerous-logs', 'use-expect'].sort());
+  t.deepEqual(
+    Object.keys(m.rules).sort(),
+    ['no-async-callback', 'no-dangerous-logs', 'use-expect'].sort()
+  );
 });

--- a/test/no-async-callback.js
+++ b/test/no-async-callback.js
@@ -1,0 +1,130 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../rules/no-async-callback';
+
+const ruleTester = avaRuleTester(test, {
+  parserOptions: {
+    ecmaVersion: 2017
+  }
+});
+
+const ruleId = 'no-async-callback';
+const message = 'Do not use callback parameters inside an async function';
+
+ruleTester.run('no-async-callback', rule, {
+  valid: [
+    'function foo(cb) {}',
+    'async function foo() {}',
+    'async (foo) => {}',
+    '(cb) => {}',
+    'foo(function(cb) {})',
+    'foo(async function() {})',
+    {
+      code: 'async function foo(cb) {}',
+      options: [{callbacks: ['bar', 'baz']}]
+    }
+  ],
+  invalid: [
+    {
+      code: 'async function foo(cb) {}',
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 20
+        }
+      ]
+    },
+    {
+      code: 'async function foo(a, b, cb, d) {}',
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 26
+        }
+      ]
+    },
+    {
+      code: 'async function foo(done) {}',
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 20
+        }
+      ]
+    },
+    {
+      code: 'async function foo(callback) {}',
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 20
+        }
+      ]
+    },
+    {
+      code: 'async function foo(next) {}',
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 20
+        }
+      ]
+    },
+    {
+      code: 'async (foo, cb) => {}',
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 13
+        }
+      ]
+    },
+    {
+      code: 'foo(async function(cb) {})',
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 20
+        }
+      ]
+    },
+    {
+      code: 'foo(async function(bar) {})',
+      options: [{callbacks: ['bar', 'baz']}],
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 20
+        }
+      ]
+    },
+    {
+      code: 'foo(async function(baz) {})',
+      options: [{callbacks: ['bar', 'baz']}],
+      errors: [
+        {
+          ruleId,
+          message,
+          line: 1,
+          column: 20
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Ajoute une règle qui interdit l'utilisation de callbacks (done, cb, callback, next) dans des fonctions async
Avec possibilité de surcharger dans la config ESLint le nom des callbacks