### PR TITLE
Add new plugin: jsx-no-logical-expression

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
         "self/coorpacademy/no-async-callback": "off",
         "self/coorpacademy/no-dangerous-logs": "off",
         "self/coorpacademy/no-overwriting-spread": "off",
+        "self/coorpacademy/jsx-no-logical-expression": "off",
         "unicorn/filename-case": "warn"
     }
 }

--- a/src/config/core.js
+++ b/src/config/core.js
@@ -43,6 +43,7 @@ module.exports = {
     '@coorpacademy/coorpacademy/no-async-callback': 'error',
     '@coorpacademy/coorpacademy/no-dangerous-logs': 'error',
     '@coorpacademy/coorpacademy/no-overwriting-spread': 'error',
+    '@coorpacademy/coorpacademy/jsx-no-logical-expression': 'error',
 
     'import/default': 'error',
     'import/export': 'error',

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   'no-async-callback': require('./no-async-callback'),
   'no-dangerous-logs': require('./no-dangerous-logs'),
-  'no-overwriting-spread': require('./no-overwriting-spread')
+  'no-overwriting-spread': require('./no-overwriting-spread'),
+  'jsx-no-logical-expression': require('./jsx-no-logical-expression')
 };

--- a/src/rules/jsx-no-logical-expression.js
+++ b/src/rules/jsx-no-logical-expression.js
@@ -1,0 +1,17 @@
+function create(context) {
+  return {
+    LogicalExpression: node => {
+      if (node.right.type === 'JSXElement') {
+        context.report({
+          node,
+          message: 'JSX should not use logical expression'
+        });
+      }
+    }
+  };
+}
+
+module.exports = {
+  create,
+  meta: {}
+};

--- a/src/rules/jsx-no-logical-expression.js
+++ b/src/rules/jsx-no-logical-expression.js
@@ -23,7 +23,7 @@ const create = context => ({
       context.report({
         node,
         message: 'JSX should not use logical expression',
-        fix: createFixer(node, context)
+        fix: createFixer(node, context.getSourceCode().getText())
       });
     }
   }
@@ -31,6 +31,7 @@ const create = context => ({
 
 module.exports = {
   create,
+  createFixer,
   meta: {
     docs: {
       description: 'Prevent falsy values to be printed'

--- a/src/rules/jsx-no-logical-expression.js
+++ b/src/rules/jsx-no-logical-expression.js
@@ -1,17 +1,40 @@
-function create(context) {
-  return {
-    LogicalExpression: node => {
-      if (node.right.type === 'JSXElement') {
-        context.report({
-          node,
-          message: 'JSX should not use logical expression'
-        });
-      }
+const createFixer = ({range, left, right, operator}, source) => fixer => {
+  const {start: leftStart, end: leftEnd} = left;
+  const {start: rightStart} = right;
+  const operatorRange = [leftEnd, rightStart];
+  const operatorText = source.slice(...operatorRange);
+
+  if (operator === '||') {
+    const leftText = source.slice(leftStart, leftEnd);
+    return [
+      fixer.replaceTextRange(operatorRange, operatorText.replace(operator, `? ${leftText} :`))
+    ];
+  }
+
+  return [
+    fixer.replaceTextRange(operatorRange, operatorText.replace(operator, '?')),
+    fixer.insertTextAfterRange(range, ' : null')
+  ];
+};
+
+const create = context => ({
+  LogicalExpression: node => {
+    if (node.right.type === 'JSXElement') {
+      context.report({
+        node,
+        message: 'JSX should not use logical expression',
+        fix: createFixer(node, context)
+      });
     }
-  };
-}
+  }
+});
 
 module.exports = {
   create,
-  meta: {}
+  meta: {
+    docs: {
+      description: 'Prevent falsy values to be printed'
+    },
+    fixable: 'code'
+  }
 };

--- a/test/jsx-no-logical-expression.js
+++ b/test/jsx-no-logical-expression.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import avaRuleTester from 'eslint-ava-rule-tester';
+import rule from '../src/rules/jsx-no-logical-expression';
+
+const ruleTester = avaRuleTester(test, {
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+});
+
+const ruleId = 'jsx-no-logical-expression';
+const message = 'JSX should not use logical expression';
+
+const error = {
+  ruleId,
+  message,
+  type: 'LogicalExpression'
+};
+
+ruleTester.run(ruleId, rule, {
+  valid: [
+    '{true ? <div /> : null}',
+    '{false || false ? <div /> : null}',
+    '{true && true ? <div /> : null}'
+  ],
+  invalid: [
+    {
+      code: '{true && <div />}',
+      errors: [error]
+    },
+    {
+      code: '{true || <div />}',
+      errors: [error]
+    }
+  ]
+});

--- a/test/jsx-no-logical-expression.js
+++ b/test/jsx-no-logical-expression.js
@@ -29,22 +29,27 @@ ruleTester.run(ruleId, rule, {
   invalid: [
     {
       code: '{true && <div />}',
+      output: '{true ? <div /> : null}',
       errors: [error]
     },
     {
-      code: '{true || <div />}',
+      code: '{foo || <div />}',
+      output: '{foo ? foo : <div />}',
       errors: [error]
     },
     {
       code: '{false && <div />}',
+      output: '{false ? <div /> : null}',
       errors: [error]
     },
     {
       code: '{undefined && <div />}',
+      output: '{undefined ? <div /> : null}',
       errors: [error]
     },
     {
       code: '{0 && <div />}',
+      output: '{0 ? <div /> : null}',
       errors: [error]
     }
   ]

--- a/test/jsx-no-logical-expression.js
+++ b/test/jsx-no-logical-expression.js
@@ -34,6 +34,18 @@ ruleTester.run(ruleId, rule, {
     {
       code: '{true || <div />}',
       errors: [error]
+    },
+    {
+      code: '{false && <div />}',
+      errors: [error]
+    },
+    {
+      code: '{undefined && <div />}',
+      errors: [error]
+    },
+    {
+      code: '{0 && <div />}',
+      errors: [error]
     }
   ]
 });

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -25,6 +25,11 @@ test('index should contain all configurations', t => {
 test('index should contain all rules', t => {
   t.deepEqual(
     Object.keys(m.rules).sort(),
-    ['no-async-callback', 'no-dangerous-logs', 'no-overwriting-spread'].sort()
+    [
+      'no-async-callback',
+      'no-dangerous-logs',
+      'no-overwriting-spread',
+      'jsx-no-logical-expression'
+    ].sort()
   );
 });


### PR DESCRIPTION
## Detailed purpose of the PR

This PR adds new plugin to avoid using logical expression in JSX and having this [kind of error](https://github.com/facebook/react-native/blob/v0.61.5/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js#L6025) due to logical expression returning falsy values from other types (ie: empty string, 0, etc.) and rendered out of a `Text` component.

To understand what's a `LogicalExpression` in AST, [check it out](https://astexplorer.net/#/gist/874444948bbabaf14e531d83fde0f6e3/197c027212e54f2e7eb05b75c06e4573e887f17b).

### Result

#### Check

<img width="956" alt="Capture d’écran 2020-01-13 à 17 04 43" src="https://user-images.githubusercontent.com/8419208/72271240-d2b5ac00-3626-11ea-8d27-2afe3d8d6da1.png">
<img width="888" alt="Capture d’écran 2020-01-13 à 17 03 51" src="https://user-images.githubusercontent.com/8419208/72271243-d47f6f80-3626-11ea-9711-e7225fb382d1.png">

<details>
  <summary>Mobile output</summary>
  <p>

```
$ eslint . --quiet

./src/app.js
  81:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/authentication-details.js
  121:16  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/button-sticky.js
  43:6  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/button.js
  170:18  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/card-header.js
  82:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  83:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  87:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  90:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  93:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/card.js
  38:9   error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  38:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/carousel.js
  94:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/catalog-item-author.js
  46:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  52:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/catalog-item-content.js
  24:12  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/catalog-item-footer.js
  146:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  157:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  183:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/catalog-item.js
  104:12  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/context.js
  78:12  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/correction.js
  251:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  256:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  264:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  269:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  334:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  335:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  346:16  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  360:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/drop-zone.js
  69:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/header-back-button.js
  58:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  61:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  64:8  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/header-slide-title.js
  66:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  71:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  76:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/hero.js
  104:20  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  112:20  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/lesson.js
  83:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/level-end.js
  225:20  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  238:20  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  240:24  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  245:24  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  247:28  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  260:20  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  280:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/lives.js
  255:12  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  306:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/modal-error.js
  114:16  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  121:16  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  126:12  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/modal.js
  80:6  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/preview.js
   78:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
   80:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
   87:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
   90:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
   92:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  101:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  117:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/qr-code-scanner.js
  36:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/question-choice.js
  112:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/question-choices.js
  102:18  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  122:20  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/question.js
  142:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/tooltip.js
  69:12  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  70:12  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/components/video.js
  137:8   error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  146:8   error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  177:12  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  180:8   error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression
  189:14  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/screens/authentication.js
  130:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/screens/correction.js
  154:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

./src/screens/qr-code.js
  70:10  error  JSX should not use logical expression  @coorpacademy/coorpacademy/jsx-no-logical-expression

✖ 73 problems (73 errors, 0 warnings)
```

  </p>
</details>

#### Fix

<img width="690" alt="Capture d’écran 2020-01-15 à 11 19 30" src="https://user-images.githubusercontent.com/8419208/72425891-f133b880-3788-11ea-8a30-ccd91fb933a7.png">

### Coverage

<img width="738" alt="Capture d’écran 2020-01-15 à 11 18 18" src="https://user-images.githubusercontent.com/8419208/72425837-d19c9000-3788-11ea-8a00-d653ee5c1af2.png">

### Testing strategy

- [x] I ensured my code is tested: plugin and fixer unit tests (from 81 to 96 tests)
- [x] I took care to mention breaking changes and extra libs if appropriate
